### PR TITLE
Switch session handling to Redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ gevent-websocket==0.10.1
 pillow==10.4.0
 python-engineio==4.7.1
 eventlet==0.33.3
-
-
+redis==5.0.4
+Flask-Session==0.5.0
 openpyxl==3.1.2


### PR DESCRIPTION
## Summary
- use Redis for token sessions in main proxy
- add Redis-backed session management for user manager
- throttle login attempts after five failures
- add dependencies for Redis session management

## Testing
- `python -m py_compile hueying_proxy-main/main.py hueying_usermanager/server.py`

------
https://chatgpt.com/codex/tasks/task_e_688751a81f708332a90b665c15db6842